### PR TITLE
修复 `get_time_us` 的精度问题

### DIFF
--- a/os/src/timer.rs
+++ b/os/src/timer.rs
@@ -14,7 +14,7 @@ pub fn get_time() -> usize {
 
 /// get current time in microseconds
 pub fn get_time_us() -> usize {
-    time::read() / (CLOCK_FREQ / MICRO_PER_SEC)
+    (time::read() as f64 / (CLOCK_FREQ as f64 / MICRO_PER_SEC as f64)) as _
 }
 
 /// set the next timer interrupt


### PR DESCRIPTION
`config::CLOCK_FREQ: usize = 12_500_000`，`timer::MICRO_PER_SEC: usize = 1_000_000`，直接除会舍掉 `0.5`，有较大的误差。实验如果使用 `get_time` 实现计时会无法通过测试。