### PR TITLE
[ch4] Make TaskStatus ABI consistent with tests

### DIFF
--- a/os/src/task/task.rs
+++ b/os/src/task/task.rs
@@ -58,6 +58,7 @@ impl TaskControlBlock {
 #[derive(Copy, Clone, PartialEq)]
 /// task status: UnInit, Ready, Running, Exited
 pub enum TaskStatus {
+    UnInit,
     Ready,
     Running,
     Exited,


### PR DESCRIPTION
在对应的 [rCore-Tutorial-Test-2022S](https://github.com/LearningOS/rCore-Tutorial-Test-2022S) 中，`lib.rs` 里 `TaskStatus` 定义如下：

```rust
#[derive(Copy, Clone, PartialEq, Debug)]
pub enum TaskStatus {
    UnInit,
    Ready,
    Running,
    Exited,
}
```

在第四章中不知为何 `UnInit` 项消失了而无法通过测试。（其它章看起来没有问题。）
```rust
#[derive(Copy, Clone, PartialEq)]
pub enum TaskStatus {
    // UnInit 不见了
    Ready,
    Running,
    Exited,
}
```